### PR TITLE
Add functionality to trigger action on push

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,8 @@
-on: [pull_request]
+name: Test Workflow
+
+on:
+  pull_request:
+  push:
 
 jobs:
   test_job:

--- a/DISTRIBUTION.md
+++ b/DISTRIBUTION.md
@@ -1,4 +1,3 @@
 ## To create a new version
 - Install compile tool: `npm i -g @vercel/ncc`  [@vercel/ncc](https://github.com/vercel/ncc)
 - Package: `npm run package`
-- 

--- a/README.md
+++ b/README.md
@@ -24,3 +24,5 @@ See [action.yml](action.yml)
           github-token: ${{ github.token }}
           include-pr-link: true
 ```
+
+This action can be used on pull request or push triggers. Other events are ignored 

--- a/dist/index.js
+++ b/dist/index.js
@@ -12821,7 +12821,7 @@ async function run () {
   try {
     const { fileToWatch, slackTitle, slackChannel, slackWebhook, githubToken, includePRLink, eventName } = getInputs()
     let didNotify
-    if (eventName === 'pull_request') {
+    if (eventName === 'pull_request' || eventName === 'push') {
       const diff = await getPRDiff(githubToken)
       const additions = getAdditions(diff, fileToWatch)
       if (additions.length === 0) {

--- a/index.js
+++ b/index.js
@@ -63,7 +63,7 @@ async function run () {
   try {
     const { fileToWatch, slackTitle, slackChannel, slackWebhook, githubToken, includePRLink, eventName } = getInputs()
     let didNotify
-    if (eventName === 'pull_request') {
+    if (eventName === 'pull_request' || eventName === 'push') {
       const diff = await getPRDiff(githubToken)
       const additions = getAdditions(diff, fileToWatch)
       if (additions.length === 0) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "slack-file-watcher-action",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Github action that notifies a slack channel when a file has been changed",
   "main": "dist/index.js",
   "scripts": {

--- a/testdir/translations.xml
+++ b/testdir/translations.xml
@@ -4,4 +4,5 @@
     <string name="test2"  translatable="false">key2</string>
     <string name="test3"  translatable="false">key3</string>
     <string name="test4"  translatable="false">key4</string>
+    <string name="test5"  translatable="false">keyr</string>
 </resources>


### PR DESCRIPTION
Message for the same keys are being send to #stm-content. This is because we have configured this action to be run on a pull-request. But pull_requests updated multiple times. 

I have added "push" event triggers to this action so we can configure the android project to only run on pushes to `main`